### PR TITLE
Allow session_event and helper_metadata to be set

### DIFF
--- a/vumi_http_api/resource.py
+++ b/vumi_http_api/resource.py
@@ -85,6 +85,10 @@ class MsgCheckHelpers(object):
     def is_session_event(value):
         return value in TransportUserMessage.SESSION_EVENTS
 
+    @staticmethod
+    def is_dict_or_none(value):
+        return (value is None) or (isinstance(value, dict))
+
     # The following checkers perform more complex validation based on the
     # entire payload and the API config.
 
@@ -108,6 +112,8 @@ class SendToOptions(MsgOptions):
     WHITELIST = {
         'content': MsgCheckHelpers.is_unicode_or_none,
         'to_addr': MsgCheckHelpers.is_unicode,
+        'helper_metadata': MsgCheckHelpers.is_dict_or_none,
+        'session_event': MsgCheckHelpers.is_session_event,
     }
 
     VALIDATION = (

--- a/vumi_http_api/resource.py
+++ b/vumi_http_api/resource.py
@@ -168,11 +168,12 @@ class MessageResource(BaseResource):
             self.client_error_response(request, msg_options.error_msg)
             return
 
-        helper_metadata = {}
+        helper_metadata = msg_options.helper_metadata or {}
 
         msg = yield self.worker.send_to(
             msg_options.to_addr, msg_options.content,
-            endpoint='default', helper_metadata=helper_metadata)
+            endpoint='default', session_event=msg_options.session_event,
+            helper_metadata=helper_metadata)
 
         self.successful_send_response(request, msg)
 

--- a/vumi_http_api/tests/test_resource.py
+++ b/vumi_http_api/tests/test_resource.py
@@ -95,6 +95,12 @@ class TestMsgCheckHelpers(TestCase):
         self.assertTrue(MsgCheckHelpers.is_unicode_or_none(None))
         self.assertFalse(MsgCheckHelpers.is_unicode("123"))
 
+    def test_is_dict_or_none(self):
+        self.assertTrue(MsgCheckHelpers.is_dict_or_none({}))
+        self.assertTrue(MsgCheckHelpers.is_dict_or_none({'foo': 'bar'}))
+        self.assertTrue(MsgCheckHelpers.is_dict_or_none(None))
+        self.assertFalse(MsgCheckHelpers.is_dict_or_none(u'123'))
+
     def test_is_session_event(self):
         for event in TransportUserMessage.SESSION_EVENTS:
             self.assertTrue(MsgCheckHelpers.is_session_event(event))

--- a/vumi_http_api/tests/test_resource.py
+++ b/vumi_http_api/tests/test_resource.py
@@ -148,6 +148,22 @@ class TestSendToOptions(TestCase):
         self.assertFalse(SendToOptions({"to_addr": 123}, {}).is_valid)
         self.assertFalse(SendToOptions({"to_addr": None}, {}).is_valid)
 
+    def test_helper_metadata_whitelist(self):
+        self.assertTrue(SendToOptions(
+            {"to_addr": u"", "helper_metadata": {}}, {}).is_valid)
+        self.assertTrue(SendToOptions(
+            {"to_addr": u"", "helper_metadata": None}, {}).is_valid)
+        self.assertFalse(SendToOptions(
+            {"to_addr": u"", "helper_metadata": "str"}, {}).is_valid)
+
+    def test_session_event_whitelist(self):
+        self.assertTrue(SendToOptions(
+            {"to_addr": u"", "session_event": "new"}, {}).is_valid)
+        self.assertTrue(SendToOptions(
+            {"to_addr": u"", "session_event": None}, {}).is_valid)
+        self.assertFalse(SendToOptions(
+            {"to_addr": u"", "session_event": "bar"}, {}).is_valid)
+
     def test_white_listing(self):
         opts = SendToOptions({"bad": 5, "to_addr": u"dummy"}, {})
         self.assertTrue(opts.is_valid)

--- a/vumi_http_api/tests/test_vumi_app.py
+++ b/vumi_http_api/tests/test_vumi_app.py
@@ -201,6 +201,21 @@ class TestVumiApiWorkerSendToEndpoint(TestVumiApiWorkerBase):
         self.assertEqual(sent_msg['helper_metadata'], {})
 
     @inlineCallbacks
+    def test_send_to_invalid_helper_metadata(self):
+        yield self.start_app_worker()
+        msg = {
+            'to_addr': '+1234',
+            'helper_metadata': {'voice': 'err'},
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation)
+        response = yield http_request_full(
+            url, json.dumps(msg), self.auth_headers, method='PUT')
+        self.assert_bad_request(
+            response,
+            "Invalid or missing value for payload key 'voice'")
+
+    @inlineCallbacks
     def test_send_to_with_zero_worker_concurrency(self):
         """
         When the worker_concurrency_limit is set to zero, our requests will

--- a/vumi_http_api/tests/test_vumi_app.py
+++ b/vumi_http_api/tests/test_vumi_app.py
@@ -149,6 +149,8 @@ class TestVumiApiWorkerSendToEndpoint(TestVumiApiWorkerBase):
         msg = {
             'to_addr': '+2345',
             'content': 'foo',
+            'helper_metadata': {'foo': 'bar'},
+            'session_event': 'new',
             'message_id': 'evil_id',
         }
 
@@ -169,6 +171,8 @@ class TestVumiApiWorkerSendToEndpoint(TestVumiApiWorkerBase):
         self.assertEqual(sent_msg['message_id'], put_msg['message_id'])
         self.assertEqual(sent_msg['to_addr'], msg['to_addr'])
         self.assertEqual(sent_msg['from_addr'], None)
+        self.assertEqual(sent_msg['session_event'], 'new')
+        self.assertEqual(sent_msg['helper_metadata'], {'foo': 'bar'})
 
     @inlineCallbacks
     def test_send_to_with_zero_worker_concurrency(self):

--- a/vumi_http_api/tests/test_vumi_app.py
+++ b/vumi_http_api/tests/test_vumi_app.py
@@ -149,7 +149,7 @@ class TestVumiApiWorkerSendToEndpoint(TestVumiApiWorkerBase):
         msg = {
             'to_addr': '+2345',
             'content': 'foo',
-            'helper_metadata': {'foo': 'bar'},
+            'helper_metadata': {'voice': {'foo': 'bar'}},
             'session_event': 'new',
             'message_id': 'evil_id',
         }
@@ -172,7 +172,33 @@ class TestVumiApiWorkerSendToEndpoint(TestVumiApiWorkerBase):
         self.assertEqual(sent_msg['to_addr'], msg['to_addr'])
         self.assertEqual(sent_msg['from_addr'], None)
         self.assertEqual(sent_msg['session_event'], 'new')
-        self.assertEqual(sent_msg['helper_metadata'], {'foo': 'bar'})
+        self.assertEqual(
+            sent_msg['helper_metadata'], {'voice': {'foo': 'bar'}})
+
+    @inlineCallbacks
+    def test_send_to_bad_helper_metadata(self):
+        yield self.start_app_worker()
+        msg = {
+            'to_addr': '+2345',
+            'helper_metadata': {'foo': 'bar'},
+        }
+
+        url = '%s/%s/messages.json' % (self.url, self.conversation)
+        response = yield http_request_full(url, json.dumps(msg),
+                                           self.auth_headers, method='PUT')
+
+        self.assertEqual(response.code, http.OK)
+        self.assertEqual(
+            response.headers.getRawHeaders('content-type'),
+            ['application/json; charset=utf-8'])
+        put_msg = json.loads(response.delivered_body)
+
+        [sent_msg] = self.app_helper.get_dispatched_outbound()
+        self.assertEqual(sent_msg['to_addr'], sent_msg['to_addr'])
+        self.assertEqual(sent_msg['message_id'], put_msg['message_id'])
+        self.assertEqual(sent_msg['to_addr'], msg['to_addr'])
+        self.assertEqual(sent_msg['from_addr'], None)
+        self.assertEqual(sent_msg['helper_metadata'], {})
 
     @inlineCallbacks
     def test_send_to_with_zero_worker_concurrency(self):


### PR DESCRIPTION
For voice calls, both `session_event` and `helper_metadata` need to be set in order to make a call. We need to add them to the whitelist, and set them in the created message object.
